### PR TITLE
Fixed creation of certificate under linux

### DIFF
--- a/Fedlet/Saml2/IdentityProvider.cs
+++ b/Fedlet/Saml2/IdentityProvider.cs
@@ -25,6 +25,7 @@
  * $Id: IdentityProvider.cs,v 1.6 2010/01/19 18:23:09 ggennaro Exp $
  */
 
+using System;
 using System.Security.Cryptography.X509Certificates;
 using System.Security.Cryptography.Xml;
 using System.Text;
@@ -87,7 +88,7 @@ namespace Sun.Identity.Saml2
 
 				// Load now since a) it doesn't change and b) its a 
 				// performance dog on Win 2003 64-bit.
-				byte[] byteArray = Encoding.UTF8.GetBytes(EncodedSigningCertificate);
+				byte[] byteArray = Convert.FromBase64String(EncodedSigningCertificate);
 				SigningCertificate = new X509Certificate2(byteArray);
 			}
 			catch (XmlException xe)


### PR DESCRIPTION
This fixes inconsistent behavior for creating X509Certificate2 object from byte array. Windows implementation has built-in base64 decoding while Linux implementation doesn't.
More info here https://github.com/dotnet/runtime/issues/20173#issuecomment-280359825
According to XML Signature W3C recommendation that is used in identity provider xml certificate data contains base64 encoded certificate (see https://www.w3.org/TR/xmldsig-core1/#sec-X509Data).

@romanpolunin could you merge it and build new version of nuget package